### PR TITLE
Use Mozilla's new Etherpad Lite instance.

### DIFF
--- a/htmlpad/etherpad.py
+++ b/htmlpad/etherpad.py
@@ -2,19 +2,19 @@ import httplib
 
 from django.conf import settings
 
-PAD_TEXT_URL = "/ep/pad/export/%s/latest?format=txt"
-PAD_REV_TEXT_URL = "/ep/pad/export/%s/rev.%d?format=txt"
+PAD_TEXT_URL = "/p/%s/export/txt"
+PAD_REV_TEXT_URL = "/p/%s/%d/export/txt"
 
 protocols = dict(https=httplib.HTTPSConnection,
                  http=httplib.HTTPConnection)
-                 
+
 def _get_url(urlpath):
     conn = protocols[settings.ETHERPAD_PROTOCOL](settings.ETHERPAD_HOST)
     conn.request("GET", urlpath)
     return conn.getresponse()
 
 def get_edit_url(name):
-    return '%s://%s/%s' % (settings.ETHERPAD_PROTOCOL,
+    return '%s://%s/p/%s?useMonospaceFont=true' % (settings.ETHERPAD_PROTOCOL,
                            settings.ETHERPAD_HOST, name)
 
 def get_raw_contents(name, rev=None):

--- a/htmlpad_dot_org/settings.py
+++ b/htmlpad_dot_org/settings.py
@@ -157,7 +157,7 @@ LOGGING = {
 set_default_env(
     HTMLPAD_ROOT='',
     ETHERPAD_PROTOCOL='https',
-    ETHERPAD_HOST='etherpad.mozilla.org',
+    ETHERPAD_HOST='public.etherpad-mozilla.org',
 )
 
 HTMLPAD_ROOT = os.environ['HTMLPAD_ROOT']


### PR DESCRIPTION
This seems to do the trick. I tested with URLs including the revision and content type like:
http://127.0.0.1:8000/htmlpad.txt/rev.0/
