### PR TITLE
Etherpad Lite no longer uses a "Create Pad" button

### DIFF
--- a/htmlpad/templates/htmlpad/edit.html
+++ b/htmlpad/templates/htmlpad/edit.html
@@ -25,7 +25,7 @@ div.instructions {
 <script src="{{ STATIC_URL }}js/jquery.min.js"></script>
 <iframe id="etherpad" width="900" src="{{ etherpad_url }}"></iframe>
 
-<div class="instructions"><p>Edit the pad on the right to build your HTML page (click the <em>Create Pad</em> button if necessary). Here's a simple page you can copy-and-paste into the pad to get started:</p>
+<div class="instructions"><p>Edit the pad on the right to build your HTML page. Here's a simple page you can copy-and-paste into the pad to get started:</p>
 <pre>&lt;!DOCTYPE html&gt;
 &lt;meta charset="utf-8"&gt;
 &lt;title&gt;My First Web Page&lt;/title&gt;


### PR DESCRIPTION
By default it just creates a pad with default content e.g. http://htmlpad.org/htmlpad-new/edit
